### PR TITLE
Fix runAll functionality

### DIFF
--- a/lib/buster-autotest.js
+++ b/lib/buster-autotest.js
@@ -33,7 +33,6 @@ function printHeader() {
 
 exports.watch = function (dir, options) {
     var running = false;
-    var failed = false;
     options = options || {};
 
     function findFiles(event, callback) {
@@ -80,9 +79,8 @@ exports.watch = function (dir, options) {
             test.on("exit", function (code) {
                 var currentFailed = !!code;
                 running = false;
-                var runAll = failed && !currentFailed;
-                failed = currentFailed;
-                if (runAll) { runTests(); }
+                var runAll = !currentFailed;
+                if (runAll && typeof event !== "undefined") { runTests(); }
             });
         });
     }


### PR DESCRIPTION
The runAll functionality wasn't working for me.

After playing around with it a bit I came up with this solution.

So instead of relying on the failed variable in the closure, it will decide to run all the tests if the current test didn't fail and the event isn't undefined (i.e. it was running a specific test and it didn't fail)

:)
