### PR TITLE
Allow overriding the auto-executed command

### DIFF
--- a/lib/buster-autotest.js
+++ b/lib/buster-autotest.js
@@ -68,7 +68,8 @@ exports.watch = function (dir, options) {
         running = true;
         findFiles(event, function (files) {
             printHeader();
-            var test = cp.spawn("buster-test", prepareOptions(files));
+            var command = options.cmd || "buster-test"
+            var test = cp.spawn(command, prepareOptions(files));
 
             var cancel = throttle(1000, function () {
                 running = false;


### PR DESCRIPTION
This allows us to override the test executed by buster-autotest using a "cmd" property in the options hash. This allows reusing the watching / re-execute logic when you have a custom version of buster-test. 

e.g. in my case I have an executable called "buster-options-test" (allowing v8 options) and a matching "buster-options-autotest" which passes in the appropriate command { cmd: "buster-options-test" }
